### PR TITLE
Create private chatrooms with an empty name

### DIFF
--- a/Nvisibl.Business/ChatroomsManager.cs
+++ b/Nvisibl.Business/ChatroomsManager.cs
@@ -36,9 +36,14 @@ namespace Nvisibl.Business
 
             await EnsureUserExistsAsync(createChatroomModel.OwnerId);
 
+            if (createChatroomModel.IsShared && string.IsNullOrEmpty(createChatroomModel.ChatroomName))
+            {
+                throw new InvalidOperationException($"Shared chatrooms must specify a chatroom name.");
+            }
+
             var chatroom = new Chatroom
             {
-                Name = createChatroomModel.ChatroomName,
+                Name = createChatroomModel.ChatroomName ?? string.Empty,
                 IsShared = createChatroomModel.IsShared,
             };
             await _unitOfWork.GetRepository<IChatroomRepository>().AddAsync(chatroom);

--- a/Nvisibl.Business/Models/Chatrooms/CreateChatroomModel.cs
+++ b/Nvisibl.Business/Models/Chatrooms/CreateChatroomModel.cs
@@ -7,10 +7,9 @@ namespace Nvisibl.Business.Models.Chatrooms
         [Required]
         public int OwnerId { get; set; }
 
-        [Required]
         [MinLength(3)]
         [MaxLength(100)]
-        public string ChatroomName { get; set; } = string.Empty;
+        public string? ChatroomName { get; set; } = null;
 
         [Required]
         public bool IsShared { get; set; }

--- a/Nvisibl.Cloud/Controllers/ChatroomsController.cs
+++ b/Nvisibl.Cloud/Controllers/ChatroomsController.cs
@@ -89,7 +89,7 @@ namespace Nvisibl.Cloud.Controllers
             {
                 var chatroom = await _chatroomManagerService.CreateChatroomAsync(new CreateChatroomModel
                 {
-                    ChatroomName = request.ChatroomName,
+                    ChatroomName = request.ChatroomName ?? string.Empty,
                     OwnerId = request.OwnerId,
                     IsShared = request.IsShared,
                 });

--- a/Nvisibl.Cloud/Models/Requests/CreateChatroomRequest.cs
+++ b/Nvisibl.Cloud/Models/Requests/CreateChatroomRequest.cs
@@ -7,10 +7,9 @@ namespace Nvisibl.Cloud.Models.Requests
         [Required]
         public int OwnerId { get; set; }
 
-        [Required]
         [MinLength(3)]
         [MaxLength(100)]
-        public string ChatroomName { get; set; } = string.Empty;
+        public string? ChatroomName { get; set; } = null;
 
         public bool IsShared { get; set; } = false;
     }

--- a/Nvisibl.DataLibrary/Models/Chatroom.cs
+++ b/Nvisibl.DataLibrary/Models/Chatroom.cs
@@ -8,7 +8,6 @@ namespace Nvisibl.DataLibrary.Models
     {
         public int Id { get; set; }
 
-        [Required]
         [MaxLength(100)]
         [Column(TypeName = "varchar(100)")]
         public string Name { get; set; } = string.Empty;


### PR DESCRIPTION
Non-shared/private chatrooms will be created with an empty name, which can be changed later on by one of the users and shall be used for both. Until such a renamed occurs, which might never happen, the UI shall display the name of the other user as the chatroom name.

Shared/public chatrooms must provide a name on creation.