### PR TITLE
Load older messages when opening a chatroom for the first time

### DIFF
--- a/Nvisibl.Business/Interfaces/IMessagesManager.cs
+++ b/Nvisibl.Business/Interfaces/IMessagesManager.cs
@@ -1,4 +1,5 @@
 ﻿using Nvisibl.Business.Models.Messages;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -9,6 +10,8 @@ namespace Nvisibl.Business.Interfaces
         Task<MessageModel> CreateMessageAsync(CreateMessageModel messageModel);
 
         Task<IEnumerable<MessageModel>> GetChatroomMessagesAsync(int id, int page, int pageSize);
+
+        Task<IEnumerable<MessageModel>> GetChatroomMessagesAsync(int id, DateTime olderThan, int pageSize);
 
         Task<IEnumerable<MessageModel>> GetUserMessagesAsync(int id, int page, int pageSize);
     }

--- a/Nvisibl.Cloud/WebSockets/ChatClient.cs
+++ b/Nvisibl.Cloud/WebSockets/ChatClient.cs
@@ -46,7 +46,7 @@ namespace Nvisibl.Cloud.WebSockets
                         AuthorId = msg.AuthorId,
                         Body = msg.Body,
                         ChatroomId = msg.ChatroomId,
-                        TimeSentUtc = DateTime.Parse(msg.TimeSentUtc),
+                        TimeSentUtc = DateTime.Parse(msg.TimeSentUtc).ToUniversalTime(),
                     })));
 
             var chatrooms = chatroomsManager.GetUserChatroomsAsync(new Business.Models.Users.UserModel { Id = userId })

--- a/Nvisibl.DataLibrary/Repositories/Interfaces/IRepositoryT.cs
+++ b/Nvisibl.DataLibrary/Repositories/Interfaces/IRepositoryT.cs
@@ -16,7 +16,7 @@ namespace Nvisibl.DataLibrary.Repositories.Interfaces
 
         Task AddRangeAsync(IEnumerable<TEntity> entities);
 
-        IEnumerable<TEntity> Find(Expression<Func<TEntity, bool>> predicate);
+        IEnumerable<TEntity> Find(Expression<Func<TEntity, bool>> predicate, int maxCount = 20);
 
         TEntity Get(int id);
 

--- a/Nvisibl.DataLibrary/Repositories/Repository.cs
+++ b/Nvisibl.DataLibrary/Repositories/Repository.cs
@@ -58,14 +58,19 @@ namespace Nvisibl.DataLibrary.Repositories
             await Context.Set<TEntity>().AddRangeAsync(entities);
         }
 
-        public virtual IEnumerable<TEntity> Find(Expression<Func<TEntity, bool>> predicate)
+        public virtual IEnumerable<TEntity> Find(Expression<Func<TEntity, bool>> predicate, int maxCount = 20)
         {
             if (predicate is null)
             {
                 throw new ArgumentNullException(nameof(predicate));
             }
 
-            return Context.Set<TEntity>().Where(predicate);
+            if (maxCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxCount), maxCount, string.Empty);
+            }
+
+            return Context.Set<TEntity>().Where(predicate).Take(maxCount);
         }
 
         public virtual TEntity Get(int id)

--- a/Nvisibl.WebUI/src/App.svelte
+++ b/Nvisibl.WebUI/src/App.svelte
@@ -51,7 +51,7 @@
             </div>
             <div class="ml-2 w-3/4">
                 <div style="height: 90%;">
-                    <MessagePanel {sessionManager} />
+                    <MessagePanel {api} {sessionManager} />
                 </div>
                 <div class="py-2" style="height: 10%;">
                     <MessageComposer {sessionManager} />

--- a/Nvisibl.WebUI/src/models/chatroom.ts
+++ b/Nvisibl.WebUI/src/models/chatroom.ts
@@ -12,4 +12,5 @@ export default class Chatroom {
     public readonly name: string;
     public readonly isShared: boolean;
     public readonly users: User[];
+    public initialLoadComplete: boolean = false;
 }

--- a/Nvisibl.WebUI/src/services/sessionManager.ts
+++ b/Nvisibl.WebUI/src/services/sessionManager.ts
@@ -67,6 +67,7 @@ export default class SessionManager {
         Lockr.set(this.AuthDetailsStorageKey, null);
         this._wsProcessor.stop();
         this._wsProcessor = null;
+        this._session.webSocketSession.close();
         this._session = null;
         this.onChange.next(null);
     }


### PR DESCRIPTION
When a chatroom is opened for the first time load the last N messages and display them. Also adds the possibility of loading older messages.

## New

- add `int maxCount` argument to `IRepository.Find` to limit the number or retrieved records
- implement `IMessagesManager.GetChatroomMessagesAsync` overload for retrieving messages based on time sent
- implement `/api/chatrooms/{id}/messages?olderThan&pageSize`

## Fixes

- store chat message's time received over WS as UTC
- close the webSocketSession in WebUI when clearing the active session