### PR TITLE
Provice token metadata with login response

### DIFF
--- a/Nvisibl.Cloud/Controllers/AuthController.cs
+++ b/Nvisibl.Cloud/Controllers/AuthController.cs
@@ -107,19 +107,22 @@ namespace Nvisibl.Cloud.Controllers
                     key: jwtConfig.SecurityKey,
                     algorithm: JwtConfiguration.SecurityAlgorithm
                 );
+                var createdAt = DateTime.UtcNow;
+                var validBefore = DateTime.UtcNow.AddMinutes(5);
                 var token = new JwtSecurityToken(
                     issuer: jwtConfig.Issuer,
                     audience: jwtConfig.Audience,
                     claims: jwtClaims,
-                    notBefore: DateTime.Now,
-                    expires: DateTime.Now.AddMinutes(5),
+                    notBefore: createdAt,
+                    expires: validBefore,
                     signingCredentials: signingCredentials);
 
-                return new JsonResult(new AuthLoginResponse
-                {
-                    AccessToken = new JwtSecurityTokenHandler().WriteToken(token),
-                    UserId = chatUser!.Id,
-                });
+                return new JsonResult(new AuthLoginResponse(
+                    userId: chatUser!.Id,
+                    auth: new AuthTokenResponse(
+                        accessToken: new JwtSecurityTokenHandler().WriteToken(token),
+                        createdAt: createdAt.ToString("o"),
+                        validBefore: validBefore.ToString("o"))));
             }
             catch (Exception ex)
             {

--- a/Nvisibl.Cloud/Controllers/AuthController.cs
+++ b/Nvisibl.Cloud/Controllers/AuthController.cs
@@ -155,12 +155,10 @@ namespace Nvisibl.Cloud.Controllers
                     expires: validBefore,
                     signingCredentials: signingCredentials);
 
-                return new JsonResult(new AuthTokenResponse
-                {
-                    AccessToken = new JwtSecurityTokenHandler().WriteToken(token),
-                    CreatedAt = createdAt.ToString("o"),
-                    ValidBefore = validBefore.ToString("o"),
-                });
+                return new JsonResult(new AuthTokenResponse(
+                    accessToken: new JwtSecurityTokenHandler().WriteToken(token),
+                    createdAt: createdAt.ToString("o"),
+                    validBefore: validBefore.ToString("o")));
             }
             catch (Exception ex)
             {

--- a/Nvisibl.Cloud/Models/Responses/AuthLoginResponse.cs
+++ b/Nvisibl.Cloud/Models/Responses/AuthLoginResponse.cs
@@ -1,8 +1,16 @@
-﻿namespace Nvisibl.Cloud.Models.Responses
+﻿using System;
+
+namespace Nvisibl.Cloud.Models.Responses
 {
     public class AuthLoginResponse
     {
-        public int UserId { get; set; }
-        public string AccessToken { get; set; } = string.Empty;
+        public AuthLoginResponse(int userId, AuthTokenResponse auth)
+        {
+            UserId = userId;
+            Auth = auth ?? throw new ArgumentNullException(nameof(auth));
+        }
+
+        public int UserId { get; }
+        public AuthTokenResponse Auth { get; }
     }
 }

--- a/Nvisibl.Cloud/Models/Responses/AuthTokenResponse.cs
+++ b/Nvisibl.Cloud/Models/Responses/AuthTokenResponse.cs
@@ -1,17 +1,32 @@
-﻿namespace Nvisibl.Cloud.Models.Responses
+﻿using System;
+
+namespace Nvisibl.Cloud.Models.Responses
 {
     public class AuthTokenResponse
     {
-        public string AccessToken { get; set; } = string.Empty;
+        public AuthTokenResponse(string accessToken, string createdAt, string validBefore)
+        {
+            AccessToken = string.IsNullOrEmpty(accessToken)
+                ? throw new ArgumentException("Argument was null or empty.", nameof(accessToken))
+                : accessToken;
+            CreatedAt = string.IsNullOrEmpty(createdAt)
+                ? throw new ArgumentException("Argument was null or empty.", nameof(createdAt))
+                : createdAt;
+            ValidBefore = string.IsNullOrEmpty(validBefore)
+                ? throw new ArgumentException("Argument was null or empty.", nameof(validBefore))
+                : validBefore;
+        }
+
+        public string AccessToken { get; }
 
         /// <summary>
         /// Gets or sets the date-time at which the token was created as an UTC string.
         /// </summary>
-        public string CreatedAt { get; set; } = string.Empty;
+        public string CreatedAt { get; }
 
         /// <summary>
         /// Gets or sets the date-time until which the token is valid as an UTC string.
         /// </summary>
-        public string ValidBefore { get; set; }
+        public string ValidBefore { get; }
     }
 }

--- a/Nvisibl.WebUI/src/components/Login.svelte
+++ b/Nvisibl.WebUI/src/components/Login.svelte
@@ -28,7 +28,7 @@
             .then(({ data }) => {
                 inError = false;
                 sessionManager.startSession(new AuthDetails(
-                    data.accessToken,
+                    data.auth.accessToken,
                     new User(data.userId, username),
                 ));
                 username = '';


### PR DESCRIPTION
Provide token metadata, such as `createdAt` and `validBefore`, with the login response.